### PR TITLE
Comment the intentional fallthrough

### DIFF
--- a/msgpack-1.4.2/include/msgpack/unpack_template.h
+++ b/msgpack-1.4.2/include/msgpack/unpack_template.h
@@ -248,6 +248,7 @@ msgpack_unpack_func(int, _execute)(msgpack_unpack_struct(_context)* ctx, const c
 
             _fixed_trail_again:
                 ++p;
+                // fallthrough
 
             default:
                 if((size_t)(pe - p) < trail) { goto _out; }


### PR DESCRIPTION
Fix #11 

Currently Data-MessagePack-Stream cannot be built on ubuntu 18.04 (which has gcc 7.3.0):
```
❯ gcc --version
gcc (Ubuntu 7.3.0-16ubuntu3) 7.3.0

❯ perl Makefile.PL
...
❯ make
...
/bin/bash ../libtool  --tag=CC   --mode=compile gcc -DHAVE_CONFIG_H -I. -I..    -I../include -O3 -Wall -Wextra -Werror  -g -MT unpack.lo -MD -MP -MF .deps/unpack.Tpo -c -o unpack.lo unpack.c
libtool: compile:  gcc -DHAVE_CONFIG_H -I. -I.. -I../include -O3 -Wall -Wextra -Werror -g -MT unpack.lo -MD -MP -MF .deps/unpack.Tpo -c unpack.c  -fPIC -DPIC -o unpack.o
In file included from unpack.c:268:0:
../include/msgpack/unpack_template.h: In function ‘template_execute’:
../include/msgpack/unpack_template.h:250:17: error: this statement may fall through [-Werror=implicit-fallthrough=]
                 ++p;
                 ^~~
../include/msgpack/unpack_template.h:252:13: note: here
             default:
             ^~~~~~~
cc1: all warnings being treated as errors
```

This PR fixes this problem by the same change of https://github.com/msgpack/msgpack-c/pull/586